### PR TITLE
Extension: Remove activeTab permission

### DIFF
--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -2,7 +2,7 @@
 	"name": "__MSG_appName__",
 	"short_name": "__MSG_appShortName__",
 	"description": "__MSG_appDescription__",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"manifest_version": 2,
 	"default_locale": "en",
 	"icons": {

--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -27,7 +27,6 @@
 	},
 	"permissions": [
 		"storage",
-		"activeTab",
 		"tabs",
 		"https://api.emojit.site/*"
 	],

--- a/extension/app/scripts/background.ts
+++ b/extension/app/scripts/background.ts
@@ -1,7 +1,3 @@
-// browser.runtime.onInstalled.addListener((details) => {
-//   console.log('previousVersion', details.previousVersion)
-// })
-
 import browser from 'webextension-polyfill'
 import { setupUserSettings } from './user'
 
@@ -26,6 +22,7 @@ browser.tabs.onActivated.addListener(async ({ tabId, }) => {
 	let tabInfo = tabInfos[tabId]
 	// console.debug("tabInfo:", tabInfo)
 	if (tabInfo === undefined || tabInfo.url === undefined) {
+		// console.debug("tabInfo.url:", tabInfo.url)
 		// Mainly for when the page refreshes and they return to the tab.
 		// Needs "tabs" permission.
 		const tabs = await browser.tabs.query({ active: true, currentWindow: true })
@@ -77,13 +74,15 @@ browser.tabs.onRemoved.addListener(tabId => {
 // Needs "tabs" permission.
 browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 	// console.debug("onUpdated tabId:", tabId)
-	console.debug("onUpdated changeInfo:", changeInfo, "tab:", tab)
+	// console.debug("onUpdated changeInfo:", changeInfo, "tab:", tab)
 	const { status } = changeInfo
 	const { url } = tab
 	// Sometimes the status: 'complete' can come in multiple times.
 	if (status !== 'complete' || url === undefined) {
 		return
 	}
+
+	// console.debug("onUpdated changeInfo:", changeInfo, "tab:", tab)
 
 	// The URL changed so we should clear the top reaction.
 	browser.browserAction.setBadgeText({ tabId, text: null })

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emojit-extension",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Rate any web page.",
 	"license": "BSD-3-Clause",
 	"repository": {


### PR DESCRIPTION
Seems like it's not needed. Idk why we had it. Maybe an API used to need it?