### PR TITLE
[extension] [History] Support searching using your previous reactions

### DIFF
--- a/extension/app/_locales/de/messages.json
+++ b/extension/app/_locales/de/messages.json
@@ -111,7 +111,7 @@
 		"message": "Verlauf für die ausgewählte(n) Seite(n) gelöscht."
 	},
 	"currentReactionsIdentifier": {
-		"message": "Deine momentane(n) Reaktion(en): "
+		"message": ""
 	},
 	"badgesIdentifier": {
 		"message": "🏆 Dein(e) Abzeichen: "
@@ -132,6 +132,6 @@
 		"message": "💯 Abzeichen 🏆"
 	},
 	"earnedTimeIdentifier": {
-		"message": "📅: "
+		"message": "📅 "
 	}
 }

--- a/extension/app/_locales/de/messages.json
+++ b/extension/app/_locales/de/messages.json
@@ -98,6 +98,14 @@
 	"historyPageTitle": {
 		"message": "Geschichte"
 	},
+	"deleteSelectedPages":{
+		"message": "$count$ löschen",
+		"placeholders": {
+			"count": {
+				"content": "$1"
+			}
+		}
+	},
 	"errorGettingHistory": {
 		"message": "Beim Abrufen deines Verlaufs ist ein Fehler aufgetreten."
 	},

--- a/extension/app/_locales/en/messages.json
+++ b/extension/app/_locales/en/messages.json
@@ -98,6 +98,14 @@
 	"historyPageTitle": {
 		"message": "History"
 	},
+	"deleteSelectedPages":{
+		"message": "Delete $count$ selected",
+		"placeholders": {
+			"count": {
+				"content": "$1"
+			}
+		}
+	},
 	"errorGettingHistory": {
 		"message": "There was an error getting your history."
 	},

--- a/extension/app/_locales/en/messages.json
+++ b/extension/app/_locales/en/messages.json
@@ -81,7 +81,7 @@
 		"message": "The URL is too long. It might contain private information."
 	},
 	"badgesPageTitle": {
-		"message": "🏆 Badges 🎉"
+		"message": "🏆 Your Badges 🎉"
 	},
 	"badgeSummaryTitle": {
 		"message": "Summary"

--- a/extension/app/_locales/en/messages.json
+++ b/extension/app/_locales/en/messages.json
@@ -111,7 +111,7 @@
 		"message": "Successfully deleted the history for the selected page(s)."
 	},
 	"currentReactionsIdentifier": {
-		"message": "Your current reaction(s): "
+		"message": ""
 	},
 	"badgesIdentifier": {
 		"message": "🏆 Your badge(s): "
@@ -132,6 +132,6 @@
 		"message": "💯 Badges 🏆"
 	},
 	"earnedTimeIdentifier": {
-		"message": "📅: "
+		"message": "📅 "
 	}
 }

--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -2,7 +2,7 @@
 	"name": "__MSG_appName__",
 	"short_name": "__MSG_appShortName__",
 	"description": "__MSG_appDescription__",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"manifest_version": 2,
 	"default_locale": "en",
 	"icons": {

--- a/extension/app/pages/browser_action.html
+++ b/extension/app/pages/browser_action.html
@@ -8,7 +8,7 @@
 		#main-popup {
 			padding: 1px;
 			height: 320px;
-			width: 270px;
+			width: 300px;
 			max-height: 500px;
 			max-width: 400px;
 			font-family: Helvetica, Ubuntu, Arial, sans-serif;

--- a/extension/app/scripts/components/Badges.tsx
+++ b/extension/app/scripts/components/Badges.tsx
@@ -24,6 +24,10 @@ class Badges extends React.Component<unknown, {
 		}
 	}
 
+	componentWillMount(): void {
+		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('badgesPageTitle') || "Your Badges")
+	}
+
 	async componentDidMount() {
 		const { emojit } = await setupUserSettings(['emojit'])
 		try {
@@ -50,7 +54,7 @@ class Badges extends React.Component<unknown, {
 
 		return <Container>
 			<Typography className={classes.title} component="h4" variant="h4">
-				{getMessage('badgesPageTitle') || "🏆 Badges 🎉"}
+				{getMessage('badgesPageTitle') || "🏆 Your Badges 🎉"}
 			</Typography>
 			{this.state.badges === undefined && this.state.errorGettingBadges === undefined && <div className={classes.center}>
 				<CircularProgress size={70} style={{ color: progressSpinnerColor }}
@@ -110,7 +114,7 @@ class Badges extends React.Component<unknown, {
 										{badge.currentReactions.join("")}
 									</span>
 								</Typography>}
-								{badge.time && <Typography variant="body2" component="p">
+								{badge.time && <Typography variant="body2" component="p" color="textSecondary">
 									{getMessage('earnedTimeIdentifier') || "📅 "}{new Date(badge.time).toString()}
 								</Typography>}
 							</CardContent>

--- a/extension/app/scripts/components/Badges.tsx
+++ b/extension/app/scripts/components/Badges.tsx
@@ -22,9 +22,6 @@ class Badges extends React.Component<unknown, {
 			badges: undefined,
 			errorGettingBadges: undefined,
 		}
-	}
-
-	componentWillMount(): void {
 		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('badgesPageTitle') || "Your Badges")
 	}
 

--- a/extension/app/scripts/components/Badges.tsx
+++ b/extension/app/scripts/components/Badges.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@emogit/emojit-core'
 import { progressSpinnerColor } from '@emogit/emojit-react-core'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -10,14 +11,6 @@ import React from 'react'
 import { getMessage } from '../i18n_helper'
 import classes from '../styles/Badges.module.css'
 import { setupUserSettings } from '../user'
-
-interface Badge {
-	name: string
-	time: Date | null | undefined
-	progress: number
-	pageUrl: string | null | undefined
-	currentReactions: string[] | null | undefined
-}
 
 class Badges extends React.Component<unknown, {
 	badges: { badges: Badge[] } | undefined,
@@ -112,7 +105,10 @@ class Badges extends React.Component<unknown, {
 									</Link>
 								</Typography>}
 								{badge.currentReactions && <Typography variant="body2" component="p">
-									{getMessage('currentReactionsIdentifier') || "Your current reaction(s): "}{badge.currentReactions.join("")}
+									{getMessage('currentReactionsIdentifier') || ""}
+									<span className={classes.badgeReactions}>
+										{badge.currentReactions.join("")}
+									</span>
 								</Typography>}
 								{badge.time && <Typography variant="body2" component="p">
 									{getMessage('earnedTimeIdentifier') || "📅 "}{new Date(badge.time).toString()}

--- a/extension/app/scripts/components/History.tsx
+++ b/extension/app/scripts/components/History.tsx
@@ -143,7 +143,8 @@ class History extends React.Component<unknown, State> {
 	deletePages(): void {
 		if (confirm(getMessage('deleteSelectedPagesConfirmation'))) {
 			const { checkedPageUrls } = this.state
-			let { history, reactionCounts, reactionsFilter, searchText, shownHistory } = this.state
+			const { history } = this.state
+			let { reactionCounts, reactionsFilter, searchText, shownHistory } = this.state
 			// Make the loading spinner show.
 			this.setState({ history: undefined, shownHistory: undefined, reactionCounts: undefined, checkedPageUrls: [] }, async () => {
 				try {

--- a/extension/app/scripts/components/History.tsx
+++ b/extension/app/scripts/components/History.tsx
@@ -81,6 +81,10 @@ class History extends React.Component<unknown, State> {
 		this.handleDeleteCheckbox = this.handleDeleteCheckbox.bind(this)
 	}
 
+	componentWillMount(): void {
+		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('historyPageTitle') || "History")
+	}
+
 	async componentDidMount() {
 		const { emojit } = await setupUserSettings(['emojit'])
 		try {

--- a/extension/app/scripts/components/History.tsx
+++ b/extension/app/scripts/components/History.tsx
@@ -129,7 +129,7 @@ class History extends React.Component<unknown, {
 					color="secondary"
 					variant="contained"
 					onClick={this.deletePages}>
-					{`Delete  ${this.state.checkedPages.length} selected`}
+					{getMessage('deleteSelectedPages', this.state.checkedPages.length)}
 				</Button>
 
 				<TextField className={classes.search}

--- a/extension/app/scripts/components/History.tsx
+++ b/extension/app/scripts/components/History.tsx
@@ -146,7 +146,6 @@ class History extends React.Component<unknown, State> {
 			this.setState({ history: undefined, shownHistory: undefined, reactionCounts: undefined, checkedPageUrls: [] }, async () => {
 				try {
 					await this.state.emojit!.deleteUserReactions(checkedPageUrls)
-					this.errorHandler.showError({ errorMsg: getMessage('deleteUserPageReactionsSuccess') })
 
 					const checkedPageUrlsSet = new Set(checkedPageUrls)
 					if (history) {
@@ -166,7 +165,11 @@ class History extends React.Component<unknown, State> {
 					this.errorHandler.showError({ serviceError })
 				}
 
-				this.setState({ history, reactionCounts, reactionsFilter, searchText, shownHistory })
+				this.setState(
+					{ history, reactionCounts, reactionsFilter, searchText, shownHistory },
+					() => {
+						this.errorHandler.showError({ errorMsg: getMessage('deleteUserPageReactionsSuccess') })
+					})
 			})
 		}
 	}
@@ -212,13 +215,21 @@ class History extends React.Component<unknown, State> {
 	}
 
 	render(): React.ReactNode {
-		const { history, reactionsFilter, shownHistory } = this.state
+		const { errorGettingHistory, history, reactionsFilter, shownHistory } = this.state
 
 		return <Container>
 			<Typography className={classes.title} component="h4" variant="h4">
 				<HistoryIcon className={classes.historyIcon} color="primary" fontSize="large" />
 				{getMessage('historyPageTitle') || "History"}
 			</Typography>
+			{shownHistory === undefined && errorGettingHistory !== undefined && <Typography variant="body2" component="p" color="error">
+				{errorGettingHistory}
+			</Typography>}
+			{shownHistory === undefined && errorGettingHistory === undefined && <div className={`${classes.loadingSpinner} ${classes.center}`}>
+				<CircularProgress size={70} style={{ color: progressSpinnerColor }}
+				/>
+			</div>
+			}
 
 			{history !== undefined && history.pages.length > 0 && shownHistory !== undefined && <div>
 				{/* Toggleable reactions summary for searching. */}
@@ -276,14 +287,6 @@ class History extends React.Component<unknown, State> {
 					}}
 				/>
 			</div>}
-			{shownHistory === undefined && this.state.errorGettingHistory !== undefined && <Typography variant="body2" component="p" color="error">
-				{this.state.errorGettingHistory}
-			</Typography>}
-			{shownHistory === undefined && this.state.errorGettingHistory === undefined && <div className={classes.center}>
-				<CircularProgress size={70} style={{ color: progressSpinnerColor }}
-				/>
-			</div>
-			}
 			{history !== undefined && history.pages.length === 0 && <div>
 				<Typography variant="body2" component="p" >
 					{getMessage("noHistory")}

--- a/extension/app/scripts/components/History.tsx
+++ b/extension/app/scripts/components/History.tsx
@@ -77,12 +77,10 @@ class History extends React.Component<unknown, State> {
 			shownHistory: undefined,
 		}
 
+		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('historyPageTitle') || "History")
+
 		this.deletePages = this.deletePages.bind(this)
 		this.handleDeleteCheckbox = this.handleDeleteCheckbox.bind(this)
-	}
-
-	componentWillMount(): void {
-		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('historyPageTitle') || "History")
 	}
 
 	async componentDidMount() {
@@ -244,7 +242,7 @@ class History extends React.Component<unknown, State> {
 						direction="row"
 						justifyContent="center"
 						alignItems="center"
-						spacing={1}
+						spacing={1.8}
 					>
 						{this.state.reactionCounts?.map(rc => {
 							const { reaction, count } = rc

--- a/extension/app/scripts/components/Options.tsx
+++ b/extension/app/scripts/components/Options.tsx
@@ -58,6 +58,10 @@ class Options extends React.Component<unknown, {
 		this.setUserId = this.setUserId.bind(this)
 	}
 
+	componentWillMount(): void {
+		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('optionsPageTitle') || "Options")
+	}
+
 	componentDidMount(): void {
 		setupUserSettings(['emojit', 'userId', 'serviceUrl', 'updateIconTextWithTopPageReaction', 'themePreference']).then((userSettings) => {
 			const emojit = userSettings.emojit

--- a/extension/app/scripts/components/Options.tsx
+++ b/extension/app/scripts/components/Options.tsx
@@ -49,6 +49,8 @@ class Options extends React.Component<unknown, {
 			serviceUrl: "",
 		}
 
+		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('optionsPageTitle') || "Options")
+
 		this.deleteAllUserData = this.deleteAllUserData.bind(this)
 		this.exportData = this.exportData.bind(this)
 		this.handleChange = this.handleChange.bind(this)
@@ -56,10 +58,6 @@ class Options extends React.Component<unknown, {
 		this.resetServiceUrl = this.resetServiceUrl.bind(this)
 		this.setServiceUrl = this.setServiceUrl.bind(this)
 		this.setUserId = this.setUserId.bind(this)
-	}
-
-	componentWillMount(): void {
-		document.title = (getMessage('appName') || "Emojit") + " - " + (getMessage('optionsPageTitle') || "Options")
 	}
 
 	componentDidMount(): void {

--- a/extension/app/scripts/styles/Badges.module.css
+++ b/extension/app/scripts/styles/Badges.module.css
@@ -17,3 +17,7 @@
 	height: 100%;
 	word-break: break-word;
 }
+
+.badgeReactions {
+	font-size: 1.5em;
+}

--- a/extension/app/scripts/styles/History.module.css
+++ b/extension/app/scripts/styles/History.module.css
@@ -9,6 +9,10 @@
 	margin-bottom: 0.5rem !important;
 }
 
+div.loadingSpinner {
+	margin-top: 20%;
+}
+
 /* Toggleable reactions summary for searching. */
 /* Should look very similar to the grid for reacting to a page. */
 div.reactionsSummaryGrid {

--- a/extension/app/scripts/styles/History.module.css
+++ b/extension/app/scripts/styles/History.module.css
@@ -10,7 +10,7 @@
 }
 
 /* Toggleable reactions summary for searching. */
-/* Should look like the grid for reacting to a page. */
+/* Should look very similar to the grid for reacting to a page. */
 div.reactionsSummaryGrid {
 	flex-grow: 1;
 	/* Make sure there is an even amount of spacing on the left and right. */
@@ -44,9 +44,13 @@ div.reactionsSummaryGrid {
 }
 
 .reactionCount {
-	font-size: 1em;
-	color: grey;
+	font-size: 1.1em;
+	color: lightgrey;
 	padding-left: 0.5em;
+}
+
+button:disabled > .reactionCount {
+	color: #666;
 }
 
 .reactionPickedCount {
@@ -55,6 +59,7 @@ div.reactionsSummaryGrid {
 /* END Toggleable reactions summary for searching. */
 
 .deleteButton {
+	margin-top: 0.5rem !important;
 	margin-bottom: 0.25rem !important;
 }
 

--- a/extension/app/scripts/styles/History.module.css
+++ b/extension/app/scripts/styles/History.module.css
@@ -48,18 +48,21 @@ div.reactionsSummaryGrid {
 }
 
 .reactionCount {
-	font-size: 1.1em;
-	color: lightgrey;
+	font-size: 1em;
+	color: grey;
 	padding-left: 0.5em;
 }
 
 button:disabled > .reactionCount {
-	color: #666;
+	/* An opacity too high doesn't look right in light mode
+	and too low doesn't look right in dark mode, so use a value in the middle. */
+	opacity: 50%;
 }
 
 .reactionPickedCount {
 	color: floralwhite;
 }
+
 /* END Toggleable reactions summary for searching. */
 
 .deleteButton {

--- a/extension/app/scripts/styles/History.module.css
+++ b/extension/app/scripts/styles/History.module.css
@@ -43,5 +43,5 @@
 }
 
 .pageReactions {
-	font-size: 1.2em;
+	font-size: 1.5em;
 }

--- a/extension/app/scripts/styles/History.module.css
+++ b/extension/app/scripts/styles/History.module.css
@@ -9,6 +9,51 @@
 	margin-bottom: 0.5rem !important;
 }
 
+/* Toggleable reactions summary for searching. */
+/* Should look like the grid for reacting to a page. */
+div.reactionsSummaryGrid {
+	flex-grow: 1;
+	/* Make sure there is an even amount of spacing on the left and right. */
+	overflow-x: hidden;
+}
+
+.reactionGrid {
+	margin-top: 0.75rem;
+	min-height: 8em;
+	font-size: 1.2em;
+	margin-bottom: 0.25rem;
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
+}
+
+.reactionButton {
+	background-color: inherit;
+	font-size: inherit;
+	cursor: pointer;
+	outline: none;
+	border-radius: 16px;
+	border-color: lightgrey;
+	min-width: max-content;
+	padding: 4px;
+	padding-right: 6px;
+	padding-left: 6px;
+}
+
+.reactionButtonPicked {
+	background-color: dodgerblue;
+}
+
+.reactionCount {
+	font-size: 1em;
+	color: grey;
+	padding-left: 0.5em;
+}
+
+.reactionPickedCount {
+	color: floralwhite;
+}
+/* END Toggleable reactions summary for searching. */
+
 .deleteButton {
 	margin-bottom: 0.25rem !important;
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emojit-extension",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "Rate any web page.",
 	"license": "BSD-3-Clause",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "repository": {
     "url": "git+https://github.com/emogit/emojit.git",
     "type": "git"

--- a/react-core/src/components/Reactions.tsx
+++ b/react-core/src/components/Reactions.tsx
@@ -119,7 +119,7 @@ class Reactions extends React.Component<Props, {
 	}
 
 	hasMaxReactions(): boolean {
-		return !this.state.userReactions || this.state.userReactions.length >= MAX_NUM_EMOJIS
+		return this.state.userReactions === undefined || this.state.userReactions.length >= MAX_NUM_EMOJIS
 	}
 
 	addEmoji(reaction: string): void {

--- a/react-core/src/styles/Reactions.module.css
+++ b/react-core/src/styles/Reactions.module.css
@@ -70,3 +70,9 @@
 	margin: 2px;
 	font-size: 2em;
 }
+
+/* It wasn't clear when the button was disabled in. */
+/* This enforces showing it clearly disabled when it's disabled. */
+button.emojiTrigger:disabled {
+	opacity: 0.5;
+}


### PR DESCRIPTION
# Extension
* history: Display a summary of all of the user's reactions. You can click on them to search your history.
* history: Optimize updating history after deleting items.
* history: Increase size of current reactions.
* history: localize delete message.
* history: Move loading spinner lower.
* Add page titles for option pages.
* badges: Use lighter text color for dates.
* Bump to version "1.2.0".

## Firefox
Some improvements to the UI for Firefox:
* Make a little wider because the emoji selector was getting cut-off.
* Make it clear when the emoji button is disabled.